### PR TITLE
XAMARIN-42496-removed the note for the Drag and Drop appointments in WinUI

### DIFF
--- a/winui/Scheduler/Appointment-Drag-And-Drop.md
+++ b/winui/Scheduler/Appointment-Drag-And-Drop.md
@@ -11,8 +11,6 @@ documentation: ug
 
 The Scheduler supports to reschedule the appointment by performing the drag and drop operation.
 
-N> Due to WinUI [framework issue](https://github.com/microsoft/microsoft-ui-xaml/issues/2715), this feature isn't included in the WinUI desktop applications.
-
 ## Disable drag and drop
 
 The Scheduler supports disabling the appointment drag and drop by setting the [AppointmentEditFlag](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Scheduler.AppointmentEditFlag.html) property except [DragDrop](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Scheduler.AppointmentEditFlag.html#Syncfusion_UI_Xaml_Scheduler_AppointmentEditFlag_DragDrop). In this case, appointment drag and drop cannot be performed.

--- a/winui/Scheduler/Appointment-Editing.md
+++ b/winui/Scheduler/Appointment-Editing.md
@@ -198,8 +198,6 @@ private void Schedule_AppointmentDeleting(object sender, AppointmentDeletingEven
 
 The Scheduler has support to resize the selected appointment. This support is available for all views except  the `Month` view.
 
-N>  Due to WinUI [hovering cursor issue](https://github.com/microsoft/microsoft-ui-xaml/issues/4834), this feature isn't included in WinUI desktop applications.
-
 ### Disable appointment resize
 
 The Scheduler supports disabling the appointment resizing by setting the [AppointmentEditFlag](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Scheduler.AppointmentEditFlag.html) property except [Resize](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Scheduler.AppointmentEditFlag.html#Syncfusion_UI_Xaml_Scheduler_AppointmentEditFlag_Resize). In this case, the appointment resizing cannot be performed.


### PR DESCRIPTION
XAMARIN-42496-removed the note for the Drag and Drop appointments in WinUI