### PR TITLE
ES-904219-Provide UG Documentation for AutoFitRange support in Column Sizer.

### DIFF
--- a/winui/DataGrid/Autosize-Columns.md
+++ b/winui/DataGrid/Autosize-Columns.md
@@ -123,7 +123,7 @@ this.sfDataGrid.Columns["OrderID"].ColumnWidthMode = ColumnWidthMode.AutoLastCol
 
 <img src="Autosize-Columns-images/winui-datagrid-column-filling.png" alt="Specific Column in WinUI DataGrid Fills Remaining Width" width="100%" Height="Auto"/>
 
-## Improving Performance of Auto-Sizing Calculations
+## Column Auto Sizing for Visible Rows
 
 By default, column auto-sizing is calculated for all rows in the DataGrid. The `AutoFitRange` property allows you to specify whether auto-sizing is based on visible rows or all rows in the DataGrid. The default value for the `AutoFitRange` property is `AllRows`.
 

--- a/winui/DataGrid/Autosize-Columns.md
+++ b/winui/DataGrid/Autosize-Columns.md
@@ -125,9 +125,11 @@ this.sfDataGrid.Columns["OrderID"].ColumnWidthMode = ColumnWidthMode.AutoLastCol
 
 ## Improving Performance of Auto-Sizing Calculations
 
-By default, column auto-sizing is calculated for all rows in the DataGrid. The AutoFitRange property allows you to specify whether auto-sizing applies to visible rows or all rows in the grid. The default value for the AutoFitRange property is AllRows.
+By default, column auto-sizing is calculated for all rows in the DataGrid. The `AutoFitRange` property allows you to specify whether auto-sizing is based on visible rows or all rows in the DataGrid. The default value for the `AutoFitRange` property is AllRows.
 
 The column width adjusts based on the visible text and maintains the maximum width of the column.
+
+Below are the options available for AutoFitRange:
 
 <table>
 <tr>

--- a/winui/DataGrid/Autosize-Columns.md
+++ b/winui/DataGrid/Autosize-Columns.md
@@ -125,8 +125,9 @@ this.sfDataGrid.Columns["OrderID"].ColumnWidthMode = ColumnWidthMode.AutoLastCol
 
 ## Improving Performance of Auto-Sizing Calculations
 
-By default, the column auto-sizing calculation was performed for all rows in the DataGrid. However, we now provide support for the `AutoFitRange` property, which allows auto-sizing to be calculated for either visible rows or all rows in the grid. The default value is `AutoFitRange.AllRows`.
-While scrolling, the column width adjusts according to the visible text. When you scroll up, the width remains unchanged and retains its maximum value. Additionally, when a new record is added or edited, the column width adjusts based on the text content.
+By default, column auto-sizing is calculated for all rows in the DataGrid. The AutoFitRange property allows you to specify whether auto-sizing applies to visible rows or all rows in the grid. The default value for the AutoFitRange property is AllRows.
+
+The column width adjusts based on the visible text and maintains the maximum width of the column.
 
 <table>
 <tr>
@@ -156,6 +157,22 @@ Specifies that column auto-sizing considers all rows in the grid.
 </table>
 
 {% tabs %}
+{% highlight xaml %}
+<dataGrid:SfDataGrid x:Name="sfDataGrid"
+                        AutoGenerateColumns="False"
+                        ColumnWidthMode="AutoLastColumnFill"
+                        AutoFitRange="VisibleRows"
+                        ItemsSource="{Binding OrdersDetails}">            
+            <dataGrid:SfDataGrid.Columns>
+                <dataGrid:GridTextColumn HeaderText="Order ID" MappingName="OrderID" ColumnWidthMode="AutoLastColumnFill" />
+                <dataGrid:GridTextColumn HeaderText="Customer ID" MappingName="Customer ID" />               
+                <dataGrid:GridTextColumn HeaderText="Order Date" MappingName="OrderDate" />
+                <dataGrid:GridTextColumn HeaderText="Unit Price" MappingName="UnitPrice" />
+                <dataGrid:GridTextColumn HeaderText="Ship City" MappingName="ShipCity" />
+                <dataGrid:GridTextColumn MappingName="Country" />
+            </dataGrid:SfDataGrid.Columns>
+</dataGrid:SfDataGrid>
+{% endhighlight %}
 {% highlight c# %}
 this.sfDataGrid.AutoFitRange = Syncfusion.UI.Xaml.Grids.AutoFitRange.VisibleRows;
 {% endhighlight %}

--- a/winui/DataGrid/Autosize-Columns.md
+++ b/winui/DataGrid/Autosize-Columns.md
@@ -125,9 +125,7 @@ this.sfDataGrid.Columns["OrderID"].ColumnWidthMode = ColumnWidthMode.AutoLastCol
 
 ## Improving Performance of Auto-Sizing Calculations
 
-By default, column auto-sizing is calculated for all rows in the DataGrid. The `AutoFitRange` property allows you to specify whether auto-sizing is based on visible rows or all rows in the DataGrid. The default value for the `AutoFitRange` property is AllRows.
-
-The column width adjusts based on the visible text and maintains the maximum width of the column.
+By default, column auto-sizing is calculated for all rows in the DataGrid. The `AutoFitRange` property allows you to specify whether auto-sizing is based on visible rows or all rows in the DataGrid. The default value for the `AutoFitRange` property is `AllRows`.
 
 Below are the options available for AutoFitRange:
 
@@ -145,7 +143,7 @@ Description
 <code>VisibleRows</code>
 </td>
 <td>
-Specifies that column auto-sizing considers only the visible rows in the grid.
+Specifies that column auto-sizing considers only the visible rows in the DataGrid.
 </td>
 </tr>
 <tr>
@@ -153,27 +151,31 @@ Specifies that column auto-sizing considers only the visible rows in the grid.
 <code>AllRows</code>
 </td>
 <td>
-Specifies that column auto-sizing considers all rows in the grid.
+Specifies that column auto-sizing considers all rows in the DataGrid.
 </td>
 </tr>
 </table>
 
+In `AutoFitRange.VisibleRows` mode, column widths are calculated based on the content of the visible rows and maintain the column's maximum width.This approach enhances performance by calculating the width based only on the visible rows, thus avoiding unnecessary calculations for rows that are not currently displayed.
+
+
 {% tabs %}
 {% highlight xaml %}
-<dataGrid:SfDataGrid x:Name="sfDataGrid"
-                        AutoGenerateColumns="False"
-                        ColumnWidthMode="AutoLastColumnFill"
-                        AutoFitRange="VisibleRows"
-                        ItemsSource="{Binding OrdersDetails}">            
-            <dataGrid:SfDataGrid.Columns>
-                <dataGrid:GridTextColumn HeaderText="Order ID" MappingName="OrderID" ColumnWidthMode="AutoLastColumnFill" />
-                <dataGrid:GridTextColumn HeaderText="Customer ID" MappingName="Customer ID" />               
-                <dataGrid:GridTextColumn HeaderText="Order Date" MappingName="OrderDate" />
-                <dataGrid:GridTextColumn HeaderText="Unit Price" MappingName="UnitPrice" />
-                <dataGrid:GridTextColumn HeaderText="Ship City" MappingName="ShipCity" />
-                <dataGrid:GridTextColumn MappingName="Country" />
-            </dataGrid:SfDataGrid.Columns>
-</dataGrid:SfDataGrid>
+  <dataGrid:SfDataGrid x:Name="sfDataGrid"
+                  AutoGenerateColumns="False"
+                  ColumnWidthMode="Auto"
+                  AutoFitRange="VisibleRows"
+                  GridLinesVisibility="Both"
+                  ItemsSource="{Binding OrdersDetails}">
+      <dataGrid:SfDataGrid.Columns>
+          <dataGrid:GridTextColumn HeaderText="Order ID" MappingName="OrderID" />
+          <dataGrid:GridTextColumn HeaderText="Customer ID" MappingName="CustomerID" />
+          <dataGrid:GridTextColumn HeaderText="Order Date" MappingName="OrderDate" />
+          <dataGrid:GridTextColumn HeaderText="Unit Price" MappingName="UnitPrice" />
+          <dataGrid:GridTextColumn HeaderText="Ship City" MappingName="ShipCity" />
+          <dataGrid:GridTextColumn MappingName="Country" />
+      </dataGrid:SfDataGrid.Columns>
+  </dataGrid:SfDataGrid>
 {% endhighlight %}
 {% highlight c# %}
 this.sfDataGrid.AutoFitRange = Syncfusion.UI.Xaml.Grids.AutoFitRange.VisibleRows;

--- a/winui/DataGrid/Autosize-Columns.md
+++ b/winui/DataGrid/Autosize-Columns.md
@@ -123,6 +123,44 @@ this.sfDataGrid.Columns["OrderID"].ColumnWidthMode = ColumnWidthMode.AutoLastCol
 
 <img src="Autosize-Columns-images/winui-datagrid-column-filling.png" alt="Specific Column in WinUI DataGrid Fills Remaining Width" width="100%" Height="Auto"/>
 
+## Improving Performance of Auto-Sizing Calculations
+
+By default, the column auto-sizing calculation was performed for all rows in the DataGrid. However, we now provide support for the `AutoFitRange` property, which allows auto-sizing to be calculated for either visible rows or all rows in the grid. The default value is `AutoFitRange.AllRows`.
+While scrolling, the column width adjusts according to the visible text. When you scroll up, the width remains unchanged and retains its maximum value. Additionally, when a new record is added or edited, the column width adjusts based on the text content.
+
+<table>
+<tr>
+<th>
+Type
+</th>
+<th>
+Description
+</th>
+</tr>
+<tr>
+<td>
+<code>VisibleRows</code>
+</td>
+<td>
+Specifies that column auto-sizing considers only the visible rows in the grid.
+</td>
+</tr>
+<tr>
+<td>
+<code>AllRows</code>
+</td>
+<td>
+Specifies that column auto-sizing considers all rows in the grid.
+</td>
+</tr>
+</table>
+
+{% tabs %}
+{% highlight c# %}
+this.sfDataGrid.AutoFitRange = Syncfusion.UI.Xaml.Grids.AutoFitRange.VisibleRows;
+{% endhighlight %}
+{% endtabs %}
+
 ## Refreshing autosize calculation at runtime
 
 You can refresh the autosize calculation at runtime by calling [SfDataGrid.ColumnSizer.Refresh](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.DataGrid.DataGridColumnSizer.html#Syncfusion_UI_Xaml_DataGrid_DataGridColumnSizer_Refresh) method.


### PR DESCRIPTION
**Task Link** 

https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/904219

**Description:**

I have updated the documentation to describe the auto-sizing calculation, which now supports either visible rows or all rows in the grid.
