### PR TITLE
SEO-203719-Multiple tag Missing Hotfix

### DIFF
--- a/winui/AI-AssistView/Getting-started.md
+++ b/winui/AI-AssistView/Getting-started.md
@@ -136,10 +136,6 @@ Create a simple chat collection as shown in the following code example in a new 
 {% endhighlight %}
 {% endtabs %}
 
-<<<<<<< HEAD
 ![WinUI AI AssistView control getting started](aiassistview_images/winui_aiassistview_gettingstarted.png)
 
 N> [View sample in GitHub](https://github.com/SyncfusionExamples/Syncfusion-winui-ai-assistView-examples/tree/master/Samples/Getting-Started)
-=======
-![WinUI AI AssistView control getting started](aiassistview_images/winui_aiassistview_gettingstarted.png)
->>>>>>> 88aa19a81c5f749f95544010e3e9819b587593cd


### PR DESCRIPTION
Hi @MallikaRK

Title | Description
-- | --
|Task Category |Multiple h1 tag|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/203719/|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it.  | 




Regards, 
Asha