### PR TITLE
Task(1039601): Remove Prerequisites and Troubleshooting Sections from WinUI Documentation

### DIFF
--- a/winui/AutoComplete/Highlighting.md
+++ b/winui/AutoComplete/Highlighting.md
@@ -167,9 +167,3 @@ autoComplete.HighlightedTextForeground = new SolidColorBrush(Colors.Red);
 {% endtabs %}
 
 ![WinUI AutoComplete text highlighting based on unmatched mode with contains search](Highlighting_images/winui-autocomplete-texthighlightmode-unmatched-contains.png)
-
-## Troubleshooting
-
-* **Highlighting does not appear**: Ensure `TextHighlightMode` is not set to `None` and that the bound items have a non-empty value for the path specified by `DisplayMemberPath`.
-* **Color is not applied in C#**: `HighlightedTextForeground` is a `Brush`. Use `new SolidColorBrush(Colors.Red)` instead of `Color.Red`.
-* **Empty input shows highlighted text**: When `TextSearchMode` is `Contains` and the input is empty, the entire suggestion text is considered a match.

--- a/winui/AutoComplete/Keyboard-Support.md
+++ b/winui/AutoComplete/Keyboard-Support.md
@@ -187,10 +187,3 @@ Removes the focused token from the selection.
 </td>
 </tr>
 </table>
-
-## Troubleshooting
-
-* **Drop-down does not open with the keyboard**: Ensure the control has focus and `IsDropDownOpen` is not forced to `false` in code.
-* **Navigation keys do not work**: The drop-down must be open. Verify that `ItemsSource` is bound and contains items.
-* **Token navigation keys do not respond**: Multiple selection mode must be enabled and at least one item must be selected.
-

--- a/winui/AutoComplete/Leading-and-Trailing-view.md
+++ b/winui/AutoComplete/Leading-and-Trailing-view.md
@@ -95,9 +95,3 @@ Use both properties together when you need content on both sides of the selectio
 {% endtabs %}
 
 ![WinUI AutoComplete control with a combo box in the leading view and an icon in the trailing view](Leading_and_Trailing_view_images/Leading-and-Trailing-View-in-AutoComplete.png)
-
-## Troubleshooting
-
-* **Content is not aligned**: Wrap icons in a `View box` and set an explicit `Height` and `Width` so the content scales correctly.
-* **Trailing view button steals focus**: Set `AllowFocusOnInteraction="False"` on the button so the AutoComplete retains focus.
-* **Content overflows the control**: Reduce the `Height` and `Width` of the `View box`, or set `Margin` values to create space within the control.

--- a/winui/AutoComplete/No-Result-Found.md
+++ b/winui/AutoComplete/No-Result-Found.md
@@ -66,9 +66,3 @@ The `NoResultsFoundTemplate` property is a `DataTemplate` that lets you customiz
 {% endtabs %}
 
 ![WinUI AutoComplete control with NoResultsFoundTemplate](No_Results_Found_images/No-Results-Found-Template.png)
-
-## Troubleshooting
-
-* **No-result content does not appear**: Ensure the drop-down is open and the typed text does not match any item in `ItemsSource`.
-* **Template is not rendered**: Verify that `NoResultsFoundTemplate` is set to a valid `DataTemplate`.
-* **Content appears when items are present**: Confirm that the `MinimumPrefixCount` requirement is met and that the typed text does not match any item.

--- a/winui/AutoComplete/Searching-Filtering.md
+++ b/winui/AutoComplete/Searching-Filtering.md
@@ -394,9 +394,3 @@ public class CustomAsyncFilter : IAutoCompleteFilterBehavior
 The following image shows 1 lakh of data being loaded asynchronously in a drop-down at runtime based on typed input.
 
 ![WinUI AutoComplete uses custom filtering logic to load asynchronous runtime items.](Searching_images/winui-autocomplete-asynchronous-items.png)
-
-## Troubleshooting
-
-* **Custom filter is not invoked**: Verify that the `FilterBehavior` is bound to an instance of a class that implements `IAutoCompleteFilterBehavior` and that `ItemsSource` is bound (or generated in code).
-* **Asynchronous filter cancels too aggressively**: Reduce the frequency of `CancellationTokenSource.Cancel()` calls or debounce the input.
-* **Suggestions do not appear**: Confirm that `TextSearchMode` is set and that the `GetMatchingItemsAsync` method returns a non-empty enumerable.

--- a/winui/AutoComplete/Selection.md
+++ b/winui/AutoComplete/Selection.md
@@ -311,10 +311,3 @@ autoComplete.ShowClearButton = false;
 {% endtabs %}
 
 ![WinUI AutoComplete hide clear button](Selection_images/winui-AutoComplete-hideclearbutton.png)
-
-## Troubleshooting
-
-* **Selection does not update**: Ensure `SelectionMode` is set correctly and that the bound `ItemsSource` contains the expected items.
-* **Tokens cannot be removed**: Confirm that `SelectionMode="Multiple"` is set; tokens only appear in multiple selection mode.
-* **Clear button is always visible**: Set `ShowClearButton="False"` to hide the clear button.
-* **`SelectionChanged` does not fire**: Verify that the event handler is wired up in XAML (`SelectionChanged="OnSelectionChanged"`) or in C# (`autoComplete.SelectionChanged += OnSelectionChanged;`).

--- a/winui/AutoComplete/UI-Customization.md
+++ b/winui/AutoComplete/UI-Customization.md
@@ -720,10 +720,3 @@ autoComplete.MaxDropDownHeight = 530;
 {% endtabs %}
 
 ![WinUI AutoComplete maximum drop down height changed](Styling_images/winui-autocomplete-maxdropdownheight.png)
-
-## Troubleshooting
-
-* **Templates are not applied**: Verify that `ItemTemplate`, `TokenItemTemplate`, or `TokenItemStyle` is set to a valid `DataTemplate` or `Style`, and that the `DataContext` provides the expected properties.
-* **Token image does not load**: Confirm that the image `Uri` uses the `ms-apps:///` scheme and that the file is included in the project with `Build Action` set to `Content`.
-* **Style is overridden by theme resources**: Apply the style at the control level using `TokenItemStyle` or `TextBoxStyle` so that it takes precedence over the default theme.
-* **`TextBoxStyle` has no effect**: `TextBoxStyle` only applies in single selection mode.

--- a/winui/Color-Picker/Getting-Started.md
+++ b/winui/Color-Picker/Getting-Started.md
@@ -400,10 +400,3 @@ private void ColorPicker_SelectedBrushChanged(object sender, SelectedBrushChange
 
 {% endhighlight %}
 {% endtabs %}
-
-## Troubleshooting
-
-| Issue | Possible cause | Fix |
-|-------|----------------|-----|
-| `SfColorPicker` is not resolved in XAML | The `xmlns:editors` namespace is missing | Add `xmlns:editors="using:Syncfusion.UI.Xaml.Editors"` to the root element. |
-| `ColorChannelOptions` does not change the UI | The `BrushTypeOptions` is set to a gradient-only mode | Set `BrushTypeOptions` to `SolidColorBrush` to expose the channel editors. |

--- a/winui/Color-Picker/Gradient-Color-Selection.md
+++ b/winui/Color-Picker/Gradient-Color-Selection.md
@@ -329,12 +329,3 @@ private void ColorPicker_SelectedBrushChanged(object sender, SelectedBrushChange
 
 {% endhighlight %}
 {% endtabs %}
-
-## Troubleshooting
-
-| Issue | Possible cause | Fix |
-|-------|----------------|-----|
-| Angle editor is hidden | `AxisInputOption` is not `Simple` | Set `AxisInputOption` to `Simple`. |
-| Offset editors are hidden | `AxisInputOption` is not `Advanced` | Set `AxisInputOption` to `Advanced`. |
-| Direction editor is hidden | `AxisInputOption` is not `Simple` | Set `AxisInputOption` to `Simple`. |
-| Gradient brush does not change at runtime | `BrushTypeOptions` does not include the brush type | Add the missing flag (e.g., `RadialGradientBrush`). |

--- a/winui/Color-Picker/Solid-Color-Selection.md
+++ b/winui/Color-Picker/Solid-Color-Selection.md
@@ -237,11 +237,3 @@ private void ColorPicker_SelectedBrushChanged(object sender, SelectedBrushChange
 
 {% endhighlight %}
 {% endtabs %}
-
-## Troubleshooting
-
-| Issue | Possible cause | Fix |
-|-------|----------------|-----|
-| `IsHexInputVisible` has no effect | `BrushTypeOptions` is set to a gradient mode | Set `BrushTypeOptions` to `SolidColorBrush`. |
-| Color channel editors are missing | `ColorChannelInputOptions` is set to `None` | Reset to `All` (default) or set to `TextInput`/`SliderInput`. |
-| Event handler not invoked | The XAML event name does not match the code-behind method name | Ensure the `SelectedBrushChanged="..."` attribute matches the handler signature. |

--- a/winui/Color-Picker/UI-Customization.md
+++ b/winui/Color-Picker/UI-Customization.md
@@ -92,13 +92,3 @@ colorPicker.BrushTypeOptions = BrushTypeOptions.LinearGradientBrush;
 {% endtabs %}
 
 ![Changing Color Spectrum Combination as HueSaturation in WinUI Color Picker](Getting-Started_images/winui-colorpicker-color-spectrum-component.jpg)
-
-## Troubleshooting
-
-| Issue | Possible cause | Fix |
-|-------|----------------|-----|
-| Brush mode selector is missing | `BrushTypeOptions` is set to a single brush type | Include the desired brush type in `BrushTypeOptions`, or set it to `All`. |
-| Color spectrum shape does not change | The property name is misspelled | Ensure you are using `ColorSpectrumShape` and the namespace is imported. |
-| Color spectrum components have no effect | The Spectrum Shape is `Ring` and the active mode does not support the component | Switch to `Box` shape and try again. |
-
-N> Download demo application from [GitHub](https://github.com/SyncfusionExamples/syncfusion-winui-colorpicker-examples/tree/master/Samples/SelectGradientColors)

--- a/winui/DropDown-Color-Picker/Customization-of-Color-Picker.md
+++ b/winui/DropDown-Color-Picker/Customization-of-Color-Picker.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Customization of Color Picker in WinUI DropDown Color Picker | Syncfusion
+title: Customization of Color Picker in DropDown Color Picker | Syncfusion
 description: This section describes how to customize the Color Picker embedded in the WinUI DropDown Color Picker (SfDropDownColorPicker) control.
 platform: WinUI
 control: SfDropDownColorPicker

--- a/winui/DropDown-Color-Picker/Customization-of-Color-Picker.md
+++ b/winui/DropDown-Color-Picker/Customization-of-Color-Picker.md
@@ -11,12 +11,7 @@ documentation: ug
 
 This section describes how to customize the Color Picker embedded in the [WinUI DropDown Color Picker](https://www.syncfusion.com/winui-controls/dropdown-color-picker) control.
 
-## Prerequisites
-
-Before applying the customization in this section, make sure the following are in place:
-
-- Install the [Syncfusion WinUI controls](https://www.nuget.org/packages/Syncfusion.Editors.WinUI/) NuGet package in your WinUI project.
-- Reference the `Syncfusion.UI.Xaml.Editors` namespace in your XAML page:
+Add the following namespace declaration to your XAML page:
 
 {% tabs %}
 {% highlight xaml %}
@@ -50,12 +45,3 @@ N> You can refer to the [Color Picker](https://help.syncfusion.com/winui/color-p
 The `BrushTypeOptions` property accepts a bitwise combination of `SolidColorBrush` and `LinearGradientBrush` values; the default is `SolidColorBrush | LinearGradientBrush`.
 
 ![Color picker embedded inside the DropDown Color Picker](Getting-Started_images/custom_colorpicker.jpg)
-
-## Troubleshooting
-
-| Issue | Possible cause | Suggested fix |
-|---|---|---|
-| The embedded Color Picker does not appear when the drop-down is opened. | The `AttachedFlyout` is not assigned or the namespace is missing. | Verify the `xmlns:editors` namespace is declared and the `SfColorPicker` is placed inside the `DropDownFlyout`. |
-| Build error: `SfColorPicker` or `SfDropDownColorPicker` cannot be found. | The Syncfusion WinUI Editors NuGet package is not referenced. | Install `Syncfusion.Editors.WinUI` and rebuild the project. |
-
-N> Download the demo application from [GitHub](https://github.com/SyncfusionExamples/syncfusion-winui-colorpicker-examples/tree/master/Samples/DropDownColorPicker_as_command) and run it to explore the customization shown in this section.

--- a/winui/DropDown-Color-Picker/Dropdown-Customization.md
+++ b/winui/DropDown-Color-Picker/Dropdown-Customization.md
@@ -11,14 +11,7 @@ documentation: ug
 
 This section describes various drop-down customization options available in the [WinUI DropDown Color Picker](https://www.syncfusion.com/winui-controls/dropdown-color-picker) control.
 
-## Prerequisites
-
-Before applying the customization in this section, make sure the following are in place:
-
-- Visual Studio 2022 with the **Windows application development** workload.
-- Windows App SDK (WinUI 3) and .NET 6 or later.
-- The [Syncfusion.Editors.WinUI](https://www.nuget.org/packages/Syncfusion.Editors.WinUI) NuGet package installed in your project.
-- The `Syncfusion.UI.Xaml.Editors` namespace referenced in your XAML page:
+Add the following namespace declaration to your XAML page:
 
 {% tabs %}
 {% highlight xaml %}
@@ -217,10 +210,3 @@ private void SfDropDownColorPicker_DropDownClosed(object sender, EventArgs e)
 
 {% endhighlight %}
 {% endtabs %}
-## Troubleshooting
-
-| Issue | Possible cause | Suggested fix |
-|---|---|---|
-| `DropDownPlacement` change has no effect. | `FlyoutPlacementMode` namespace is not imported. | Add `using Windows.UI.Xaml.Controls.Primitives;` in the code-behind file. |
-| `DelegateCommand<T>` cannot be found. | The Prism library is not referenced. | Install `Prism.Core` NuGet or replace with `Microsoft.UI.Xaml.Input.StandardUICommand`. |
-| The custom drop-down button template does not appear. | `DropDownMode` is not set to `Split` (for `DropDownButtonTemplate`). | Set `DropDownMode="Split"` when customizing the drop-down button. |

--- a/winui/DropDown-Color-Picker/Getting-Started.md
+++ b/winui/DropDown-Color-Picker/Getting-Started.md
@@ -246,11 +246,3 @@ private void SfDropDownColorPicker_SelectedBrushChanged(object sender, SelectedB
 
 {% endhighlight %}
 {% endtabs %}
-
-## Troubleshooting
-
-| Issue | Possible cause | Suggested fix |
-|---|---|---|
-| Build error: `SfDropDownColorPicker` cannot be found. | The Syncfusion NuGet package is not referenced. | Install `Syncfusion.Editors.WinUI` and rebuild. |
-| The XAML designer cannot resolve the `editors` prefix. | The `xmlns:editors` namespace is missing. | Add `xmlns:editors="using:Syncfusion.UI.Xaml.Editors"` to the page. |
-| `SelectedBrush` change has no effect on the UI. | The `OK` button was not clicked for interactive selection, or the brush type is incompatible. | Use a `SolidColorBrush` (or compatible brush) and click `OK` to confirm interactive selection. |


### PR DESCRIPTION
Removed the unnecessary Prerequisites and Troubleshooting sections from the AutoComplete, Color-Picker and Dropdown-Color-Palette documentation.