### PR TITLE
Documentation(1046901): Fix the getting started documentation issue for tools controls in WinUI platform(SfBusyIndicator,SfShadow,SfShimmer)

### DIFF
--- a/winui/Busy-Indicator/Getting-Started.md
+++ b/winui/Busy-Indicator/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WinUI BusyIndicator | Syncfusion®
-description: Learn how to get started with the Syncfusion® WinUI BusyIndicator control. Explore setup, features, examples, and customization options.
+title: Getting Started with WinUI BusyIndicator | SyncfusionÂ®
+description: Learn how to get started with the SyncfusionÂ® WinUI BusyIndicator control. Explore setup, features, examples, and customization options.
 platform: WinUI
 control: SfBusyIndicator
 documentation: ug
@@ -9,14 +9,14 @@ documentation: ug
 
 # Getting Started with WinUI BusyIndicator
 
-This section explains the steps required to add the BusyIndicator control and covers only the basic features needed to get started with the Syncfusion `BusyIndicator` control.
+This section explains how to add and configure the Syncfusion BusyIndicator control in a WinUI application and demonstrates the basic features required to get started.
 
 ## Creating an application with WinUI BusyIndicator control
 
 1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app).
-2. Add a reference to the [Syncfusion.Notifications.WinUI](https://www.nuget.org/packages/Syncfusion.Notifications.WinUI) NuGet package and restore packages.
+2. Add a reference to the [Syncfusion.Notifications.WinUI](https://www.nuget.org/packages/Syncfusion.Notifications.WinUI) NuGet package.
 3. Import the control namespace `Syncfusion.UI.Xaml.Notifications`. In XAML, declare `xmlns:notification="using:Syncfusion.UI.Xaml.Notifications"`; in C#, add `using Syncfusion.UI.Xaml.Notifications;`.
-4. Initialize the [SfBusyIndicator](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html) control and add it to the visual tree. Set [`IsActive`](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_IsActive) to `true` to display the indicator.
+4. Initialize the [SfBusyIndicator](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html) control and add it to the window. Set [`IsActive`](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_IsActive) to `true` to display the indicator.
 
 {% capture codesnippet1 %}
 {% tabs %}
@@ -65,7 +65,7 @@ public sealed partial class MainWindow : Window
 
 ## Setting the animation type in BusyIndicator
 
-The BusyIndicator control provides eight predefined animation types, such as `DottedCircle`, `DottedCircularFluent`, `DottedLinear`, `LinearIndicator`, `Pulse`, `Ripple`, `SingleCircle`, and `Slices`. Select any one of the animation types using the [AnimationType](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_AnimationType) property. The default value is `DottedCircle`.
+The BusyIndicator control provides eight predefined animation types, such as `DottedCircle`, `DottedCircularFluent`, `DottedLinear`, `LinearIndicator`, `Pulse`, `Ripple`, `SingleCircle`, and `Slices`. You can choose any of the predefined animation types by setting the [AnimationType](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_AnimationType) property. The default value is `DottedCircle`.
 
 {% tabs %}
 {% highlight xaml %}
@@ -109,7 +109,7 @@ public sealed partial class MainWindow : Window
 {% endhighlight %}
 {% endtabs %}
 
-## Adding content in BusyIndicator
+## Displaying content in BusyIndicator
 
 The BusyIndicator control provides an option to set the content that indicates the busy status of the control to the user, by using the [BusyContent](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_BusyContent) property. The content is rendered alongside the animation while `IsActive` is `true`, and is hidden when `IsActive` is `false`.
 
@@ -135,6 +135,8 @@ The BusyIndicator control provides an option to set the content that indicates t
 
 {% endhighlight %}
 {% highlight C# %}
+using Microsoft.UI.Xaml;
+using Syncfusion.UI.Xaml.Notifications;
 
 namespace GettingStarted;
 
@@ -154,4 +156,4 @@ public sealed partial class MainWindow : Window
 {% endhighlight %}
 {% endtabs %}
 
-![BusyIndicator control getting started in WinUI](BusyIndicator_images/winui_busyindicator_getting_started.gif)
+![WinUI BusyIndicator control getting started](BusyIndicator_images/winui_busyindicator_getting_started.gif)

--- a/winui/Busy-Indicator/Getting-Started.md
+++ b/winui/Busy-Indicator/Getting-Started.md
@@ -9,14 +9,14 @@ documentation: ug
 
 # Getting Started with WinUI BusyIndicator
 
-This section explains how to add and configure the Syncfusion BusyIndicator control in a WinUI application and demonstrates the basic features required to get started.
+This section explains how to add and configure the [SfBusyIndicator](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html) control in a WinUI application and demonstrates the basic features required to get started.
 
 ## Creating an application with WinUI BusyIndicator control
 
 1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app).
-2. Add a reference to the [Syncfusion.Notifications.WinUI](https://www.nuget.org/packages/Syncfusion.Notifications.WinUI) NuGet package.
-3. Import the control namespace `Syncfusion.UI.Xaml.Notifications`. In XAML, declare `xmlns:notification="using:Syncfusion.UI.Xaml.Notifications"`; in C#, add `using Syncfusion.UI.Xaml.Notifications;`.
-4. Initialize the [SfBusyIndicator](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html) control and add it to the window. Set [`IsActive`](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_IsActive) to `true` to display the indicator.
+2. Install the [Syncfusion.Notifications.WinUI](https://www.nuget.org/packages/Syncfusion.Notifications.WinUI) NuGet package.
+3. Import the `Syncfusion.UI.Xaml.Notifications` namespace in XAML or C#.
+4. Create and initialize the [SfBusyIndicator](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html) control and add it to the window. Set [`IsActive`](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_IsActive) to `true` to display the indicator.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/winui/Busy-Indicator/Getting-Started.md
+++ b/winui/Busy-Indicator/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WinUI BusyIndicator | SyncfusionÂ®
-description: Learn how to get started with the SyncfusionÂ® WinUI BusyIndicator control. Explore setup, features, examples, and customization options.
+title: Getting Started with WinUI BusyIndicator | Syncfusion®
+description: Learn how to get started with the Syncfusion® WinUI BusyIndicator control. Explore setup, features, examples, and customization options.
 platform: WinUI
 control: SfBusyIndicator
 documentation: ug
@@ -9,107 +9,147 @@ documentation: ug
 
 # Getting Started with WinUI BusyIndicator
 
-This section explains the steps required to add the BusyIndicator control and covers only the basic features needed to get started with Syncfusion `BusyIndicator` control.
+This section explains the steps required to add the BusyIndicator control and covers only the basic features needed to get started with the Syncfusion `BusyIndicator` control.
 
 ## Creating an application with WinUI BusyIndicator control
 
-1. Create a [WinUI 3 desktop app for C# and .NET 5](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app).
-2. Add reference to [Syncfusion.Notifications.WinUI](https://www.nuget.org/packages/Syncfusion.Notifications.WinUI) NuGet. 
-3. Import the control namespace `Syncfusion.UI.Xaml.Notifications` in XAML or C# code.
-4. Initialize the [SfBusyIndicator](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html) control.
+1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app).
+2. Add a reference to the [Syncfusion.Notifications.WinUI](https://www.nuget.org/packages/Syncfusion.Notifications.WinUI) NuGet package and restore packages.
+3. Import the control namespace `Syncfusion.UI.Xaml.Notifications`. In XAML, declare `xmlns:notification="using:Syncfusion.UI.Xaml.Notifications"`; in C#, add `using Syncfusion.UI.Xaml.Notifications;`.
+4. Initialize the [SfBusyIndicator](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html) control and add it to the visual tree. Set [`IsActive`](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_IsActive) to `true` to display the indicator.
 
 {% capture codesnippet1 %}
 {% tabs %}
 {% highlight xaml %}
 
-<Page
-    x:Class="GettingStarted.MainPage"
+<Window
+    x:Class="GettingStarted.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:GettingStarted"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:notification="using:Syncfusion.UI.Xaml.Notifications"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
     <Grid>
       <notification:SfBusyIndicator IsActive="True"/>
     </Grid>
-</Page>
+</Window>
 
 {% endhighlight %}
 {% highlight C# %}
 
-// Creating an instance of the BusyIndicator control.
-SfBusyIndicator busyIndicator = new SfBusyIndicator();
+using Microsoft.UI.Xaml;
+using Syncfusion.UI.Xaml.Notifications;
 
-// Activating the SfBusyIndicator.
-busyIndicator.IsActive = true;
+namespace GettingStarted;
+
+/// <summary>
+/// An empty window that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        this.InitializeComponent();
+        SfBusyIndicator busyIndicator = new SfBusyIndicator();
+        busyIndicator.IsActive = true;
+        this.Content = busyIndicator;
+    }
+}
 
 {% endhighlight %}
 {% endtabs %}
 {% endcapture %}
 {{ codesnippet1 | OrderList_Indent_Level_1 }}
 
-## Setting Animation Type in BusyIndicator
+## Setting the animation type in BusyIndicator
 
-The BusyIndicator control provides 8 predefined animation types like `DottedCircularFluent`, `DottedCircle`, `DottedLinear`, and so on. Users can select any one of the animation types using the [AnimationType](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_AnimationType) property.
+The BusyIndicator control provides eight predefined animation types, such as `DottedCircle`, `DottedCircularFluent`, `DottedLinear`, `LinearIndicator`, `Pulse`, `Ripple`, `SingleCircle`, and `Slices`. Select any one of the animation types using the [AnimationType](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_AnimationType) property. The default value is `DottedCircle`.
 
 {% tabs %}
 {% highlight xaml %}
 
-<notification:SfBusyIndicator IsActive="True"
-     AnimationType="DottedCircularFluent">
-</notification:SfBusyIndicator>
+<Window
+    x:Class="GettingStarted.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:GettingStarted"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:notification="using:Syncfusion.UI.Xaml.Notifications"
+    mc:Ignorable="d">
+    <Grid>
+      <notification:SfBusyIndicator IsActive="True"
+           AnimationType="DottedLinear">
+      </notification:SfBusyIndicator>
+    </Grid>
+</Window>
 
 {% endhighlight %}
 {% highlight C# %}
 
-SfBusyIndicator busyIndicator = new SfBusyIndicator();
-busyIndicator.IsActive = true;
-busyIndicator.AnimationType = BusyIndicatorAnimationType.DottedCircularFluent;
+using Microsoft.UI.Xaml;
+using Syncfusion.UI.Xaml.Notifications;
+
+namespace GettingStarted;
+
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        this.InitializeComponent();
+        SfBusyIndicator busyIndicator = new SfBusyIndicator();
+        busyIndicator.IsActive = true;
+        busyIndicator.AnimationType = BusyIndicatorAnimationType.DottedLinear;
+        this.Content = busyIndicator;
+    }
+}
 
 {% endhighlight %}
 {% endtabs %}
 
-## Adding Content in BusyIndicator
+## Adding content in BusyIndicator
 
-The BusyIndicator control provides option to set the content that indicates the busy status of the control to the users by using the [BusyContent](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_BusyContent) property.
-
-{% tabs %}
-{% highlight xaml %}
-
-<notification:SfBusyIndicator IsActive="True"
-     BusyContent="Loading">
-</notification:SfBusyIndicator>
-
-{% endhighlight %}
-{% highlight C# %}
-
-SfBusyIndicator busyIndicator = new SfBusyIndicator();
-busyIndicator.IsActive = true;
-busyIndicator.BusyContent = "Loading";
-
-{% endhighlight %}
-{% endtabs %}
-
-The following code example gives you the complete code of above configurations:
+The BusyIndicator control provides an option to set the content that indicates the busy status of the control to the user, by using the [BusyContent](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Notifications.SfBusyIndicator.html#Syncfusion_UI_Xaml_Notifications_SfBusyIndicator_BusyContent) property. The content is rendered alongside the animation while `IsActive` is `true`, and is hidden when `IsActive` is `false`.
 
 {% tabs %}
 {% highlight xaml %}
 
-<notification:SfBusyIndicator IsActive="True"
-     AnimationType="DottedCircularFluent"
-     BusyContent="Loading">
-</notification:SfBusyIndicator>
+<Window
+    x:Class="GettingStarted.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:GettingStarted"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:notification="using:Syncfusion.UI.Xaml.Notifications"
+    mc:Ignorable="d">
+    <Grid>
+      <notification:SfBusyIndicator IsActive="True"
+           AnimationType="DottedCircularFluent"
+           BusyContent="Loading">
+      </notification:SfBusyIndicator>
+    </Grid>
+</Window>
 
 {% endhighlight %}
 {% highlight C# %}
 
-SfBusyIndicator busyIndicator = new SfBusyIndicator();
-busyIndicator.IsActive = true;
-busyIndicator.AnimationType = BusyIndicatorAnimationType.DottedCircularFluent;
-busyIndicator.BusyContent = "Loading";
+namespace GettingStarted;
+
+public sealed partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        this.InitializeComponent();
+        SfBusyIndicator busyIndicator = new SfBusyIndicator();
+        busyIndicator.IsActive = true;
+        busyIndicator.AnimationType = BusyIndicatorAnimationType.DottedCircularFluent;
+        busyIndicator.BusyContent = "Loading";
+        this.Content = busyIndicator;
+    }
+}
 
 {% endhighlight %}
 {% endtabs %}

--- a/winui/Shadow/Getting-Started.md
+++ b/winui/Shadow/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WinUI Shadow | Syncfusion®
-description: Learn how to get started with the Syncfusion® WinUI SfShadow control. Explore setup, features, examples, and customization options.
+title: Getting Started with WinUI Shadow | SyncfusionÂ®
+description: Learn how to get started with the SyncfusionÂ® WinUI SfShadow control. Explore setup, features, examples, and customization options.
 platform: WinUI
 control: SfShadow
 documentation: ug
@@ -9,14 +9,14 @@ documentation: ug
 
 # Getting Started with WinUI Shadow
 
-This section explains the steps required to add the [WinUI Shadow control](https://www.syncfusion.com/winui-controls/shadow) and covers only the basic features needed to get started with the Syncfusion [SfShadow](https://help.syncfusion.com/winui/shadow/overview) control.
+This section explains how to get started with the [Shadow control](https://www.syncfusion.com/winui-controls/shadow) in a WinUI application and demonstrates the basic steps required to add and use the control.
 
 ## Creating an application with WinUI Shadow control
 
-1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app) targeting .NET 6 or later.
-2. Add reference to [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet.
-3. Import the control namespace `Syncfusion.UI.Xaml.Core` in XAML or C# code.
-4. Initialize the [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
+1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app).
+2. Install the [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet package.
+3. Import the **Syncfusion.UI.Xaml.Core** namespace in XAML or C#.
+4. Create and initialize the [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
 
 {% capture codesnippet1 %}
 {% tabs %}
@@ -71,9 +71,7 @@ namespace GettingStarted
 
 ## Applying shadow effect for image
 
-You can apply shadow effects to any [Image](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.image) using the [SfShadow](https://help.syncfusion.com/winui/shadow/overview) control.
-
-N> Before running the sample, add `Ellipse_Shadow.png` to the project's `Assets/Shadow` folder, then in **Solution Explorer** set the file's **Build Action** to `Content` and **Copy to Output Directory** to `Copy if newer` (or `Copy always`).
+You can apply shadow effects to any [Image](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.image) using the [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
 
 {% tabs %}
 {% highlight XAML %}
@@ -125,7 +123,7 @@ namespace GettingStarted
 
 ## Applying shadow effect for shape
 
-You can apply shadow effects to any [Shape](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.shape) or [Path](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.path) using the [SfShadow](https://help.syncfusion.com/winui/shadow/overview) control.
+You can apply shadow effects to any [Shape](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.shape) or [Path](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.path) using the [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
 
 {% tabs %}
 {% highlight XAML %}

--- a/winui/Shadow/Getting-Started.md
+++ b/winui/Shadow/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WinUI Shadow | SyncfusionÂ®
-description: Learn how to get started with the SyncfusionÂ® WinUI SfShadow control. Explore setup, features, examples, and customization options.
+title: Getting Started with WinUI Shadow | Syncfusion®
+description: Learn how to get started with the Syncfusion® WinUI SfShadow control. Explore setup, features, examples, and customization options.
 platform: WinUI
 control: SfShadow
 documentation: ug
@@ -9,12 +9,12 @@ documentation: ug
 
 # Getting Started with WinUI Shadow
 
-This section explains the steps required to add the [WinUI Shadow control](https://www.syncfusion.com/winui-controls/shadow) and covers only the basic features needed to get started with Syncfusion [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
+This section explains the steps required to add the [WinUI Shadow control](https://www.syncfusion.com/winui-controls/shadow) and covers only the basic features needed to get started with the Syncfusion [SfShadow](https://help.syncfusion.com/winui/shadow/overview) control.
 
 ## Creating an application with WinUI Shadow control
 
-1. Create a [WinUI 3 desktop app for C# and .NET 5](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app).
-2. Add reference to [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet. 
+1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app) targeting .NET 6 or later.
+2. Add reference to [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet.
 3. Import the control namespace `Syncfusion.UI.Xaml.Core` in XAML or C# code.
 4. Initialize the [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
 
@@ -22,8 +22,8 @@ This section explains the steps required to add the [WinUI Shadow control](https
 {% tabs %}
 {% highlight xaml %}
 
-<Page
-    x:Class="GettingStarted.MainPage"
+<Window
+    x:Class="GettingStarted.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:GettingStarted"
@@ -31,26 +31,36 @@ This section explains the steps required to add the [WinUI Shadow control](https
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:syncfusion="using:Syncfusion.UI.Xaml.Core"
     mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Title="SfShadow - Button">
     <Grid>
       <syncfusion:SfShadow>
          <Button Height="50" Width="100" Content="Button"/>
       </syncfusion:SfShadow>
     </Grid>
-</Page>
+</Window>
 
 {% endhighlight %}
 {% highlight C# %}
 
 // Creating an instance of the Shadow control.
-SfShadow shadow = new SfShadow();
-
-// Setting the SfShadow content value.
-Button button = new Button();
-button.Height = 50;
-button.Width = 100;
-button.Content = "Button";
-shadow.Content = button;
+namespace GettingStarted
+{
+    public sealed partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+            SfShadow shadow = new SfShadow();
+            // Setting the SfShadow content value.
+            Button button = new Button();
+            button.Height = 50;
+            button.Width = 100;
+            button.Content = "Button";
+            shadow.Content = button;
+            this.Content = shadow;
+        }
+    }
+}
 
 {% endhighlight %}
 {% endtabs %}
@@ -61,107 +71,163 @@ shadow.Content = button;
 
 ## Applying shadow effect for image
 
-You can apply the shadow effects for any types of [Image](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.image?view=windows-app-sdk-1.2) with the help of [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
+You can apply shadow effects to any [Image](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.image) using the [SfShadow](https://help.syncfusion.com/winui/shadow/overview) control.
+
+N> Before running the sample, add `Ellipse_Shadow.png` to the project's `Assets/Shadow` folder, then in **Solution Explorer** set the file's **Build Action** to `Content` and **Copy to Output Directory** to `Copy if newer` (or `Copy always`).
 
 {% tabs %}
 {% highlight XAML %}
 
-<syncfusion:SfShadow>
-   <Image Height="150" Width="150" Source="/Assets/Shadow/Ellipse_Shadow.png"/>
-</syncfusion:SfShadow>
+<Window
+    x:Class="GettingStarted.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:GettingStarted"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:syncfusion="using:Syncfusion.UI.Xaml.Core"
+    mc:Ignorable="d"
+    Title="SfShadow - Image">
+    <Grid>
+        <syncfusion:SfShadow>
+            <Image Height="150" Width="150" Source="/Assets/Shadow/Ellipse_Shadow.png"/>
+        </syncfusion:SfShadow>
+    </Grid>
+</Window>
 
 {% endhighlight %}
 {% highlight C# %}
 
-SfShadow shadow = new SfShadow();
-
-Image image = new Image();
-image.Height = 150;
-image.Width = 150;
-BitmapImage bitmapImage = new BitmapImage();
-bitmapImage.UriSource = new Uri("ms-appx:///Assets/Image/Ellipse_Shadow.png");
-image.Source = bitmapImage;
-shadow.Content = image;
+namespace GettingStarted
+{
+    public sealed partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+            SfShadow shadow = new SfShadow();
+            Image image = new Image();
+            image.Height = 150;
+            image.Width = 150;
+            BitmapImage bitmapImage = new BitmapImage();
+            bitmapImage.UriSource = new Uri("ms-appx:///Assets/Shadow/Ellipse_Shadow.png");
+            image.Source = bitmapImage;
+            shadow.Content = image;
+            this.Content = shadow;
+        }
+    }
+}
 
 {% endhighlight %}
 {% endtabs %}
 
 ![Shadow effect for image in WinUI](Shadow_images/winui_shadow_image.png)
 
-## Applying shadow effect for shape 
+## Applying shadow effect for shape
 
-You can apply the shadow effects for any types of [Shape](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.shape?view=windows-app-sdk-1.2) and [Path](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.path?view=windows-app-sdk-1.2) with the help of [SfShadow](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShadow.html) control.
+You can apply shadow effects to any [Shape](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.shape) or [Path](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes.path) using the [SfShadow](https://help.syncfusion.com/winui/shadow/overview) control.
 
 {% tabs %}
 {% highlight XAML %}
 
-<StackPanel Orientation="Horizontal">
-   <syncfusion:SfShadow>
-      <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>  
-   </syncfusion:SfShadow>
-   <syncfusion:SfShadow>
-      <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>  
-   </syncfusion:SfShadow>
-   <syncfusion:SfShadow>
-      <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>  
-   </syncfusion:SfShadow>
-   <syncfusion:SfShadow>
-      <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>  
-   </syncfusion:SfShadow>
-   <syncfusion:SfShadow>
-      <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>  
-   </syncfusion:SfShadow>
-</StackPanel>
+<Window
+    x:Class="GettingStarted.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:GettingStarted"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:syncfusion="using:Syncfusion.UI.Xaml.Core"
+    mc:Ignorable="d"
+    Title="SfShadow - Shape">
+    <Grid>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <syncfusion:SfShadow>
+                <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>
+            </syncfusion:SfShadow>
+            <syncfusion:SfShadow>
+                <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>
+            </syncfusion:SfShadow>
+            <syncfusion:SfShadow>
+                <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>
+            </syncfusion:SfShadow>
+            <syncfusion:SfShadow>
+                <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>
+            </syncfusion:SfShadow>
+            <syncfusion:SfShadow>
+                <Path Data="M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z" Fill="#FFD700"/>
+            </syncfusion:SfShadow>
+        </StackPanel>
+    </Grid>
+</Window>
 
 {% endhighlight %}
 {% highlight C# %}
 
-StackPanel panel = new StackPanel();
-panel.Orientation = Orientation.Horizontal;
-panel.HorizontalAlignment = HorizontalAlignment.Center;
-panel.VerticalAlignment = VerticalAlignment.Center;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using Syncfusion.UI.Xaml.Core;
+using Windows.UI;
 
-SfShadow shadow1 = new SfShadow();
-Path path1 = new Path();
-string data1 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
-path1.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data1 });    
-path1.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
-shadow1.Content = path1;
-           
-SfShadow shadow2 = new SfShadow();
-Path path2 = new Path();
-string data2 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
-path2.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data2 });
-path2.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
-shadow2.Content = path2;
-          
-SfShadow shadow3 = new SfShadow();
-Path path3 = new Path();
-string data3 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
-path3.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data3 });
-path3.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
-shadow3.Content = path3;
-           
-SfShadow shadow4 = new SfShadow();
-Path path4 = new Path();
-string data4 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
-path4.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data4 });
-path4.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
-shadow4.Content = path4;
-        
-SfShadow shadow5 = new SfShadow();
-Path path5 = new Path();
-string data5 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
-path5.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data5 });
-path5.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
-shadow5.Content = path5;
-            
-panel.Children.Add(shadow1);
-panel.Children.Add(shadow2);
-panel.Children.Add(shadow3);
-panel.Children.Add(shadow4);
-panel.Children.Add(shadow5);
-   
+namespace GettingStarted
+{
+    public sealed partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+            StackPanel panel = new StackPanel();
+            panel.Orientation = Orientation.Horizontal;
+            panel.HorizontalAlignment = HorizontalAlignment.Center;
+            panel.VerticalAlignment = VerticalAlignment.Center;
+
+            SfShadow shadow1 = new SfShadow();
+            Path path1 = new Path();
+            string data1 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
+            path1.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data1 });
+            path1.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
+            shadow1.Content = path1;
+
+            SfShadow shadow2 = new SfShadow();
+            Path path2 = new Path();
+            string data2 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
+            path2.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data2 });
+            path2.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
+            shadow2.Content = path2;
+
+            SfShadow shadow3 = new SfShadow();
+            Path path3 = new Path();
+            string data3 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
+            path3.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data3 });
+            path3.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
+            shadow3.Content = path3;
+
+            SfShadow shadow4 = new SfShadow();
+            Path path4 = new Path();
+            string data4 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
+            path4.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data4 });
+            path4.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
+            shadow4.Content = path4;
+
+            SfShadow shadow5 = new SfShadow();
+            Path path5 = new Path();
+            string data5 = "M44.5 4L54.0608 33.4114H85L59.9696 51.5886L69.5304 81L44.5 62.8228L19.4696 81L29.0304 51.5886L4 33.4114H34.9392L44.5 4Z";
+            path5.SetBinding(Microsoft.UI.Xaml.Shapes.Path.DataProperty, new Binding() { Source = data5 });
+            path5.Fill = new SolidColorBrush(Color.FromArgb(255, 255, 215, 0));
+            shadow5.Content = path5;
+
+            panel.Children.Add(shadow1);
+            panel.Children.Add(shadow2);
+            panel.Children.Add(shadow3);
+            panel.Children.Add(shadow4);
+            panel.Children.Add(shadow5);
+        }
+    }
+}
+
 {% endhighlight %}
 {% endtabs %}
 

--- a/winui/Shimmer/Getting-Started.md
+++ b/winui/Shimmer/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WinUI Shimmer | SyncfusionÂ®
-description: Learn how to get started with the SyncfusionÂ® WinUI Shimmer control. Explore setup, features, examples, and customization options.
+title: Getting Started with WinUI Shimmer | Syncfusion®
+description: Learn how to get started with the Syncfusion® WinUI Shimmer control. Explore setup, features, examples, and customization options.
 platform: WinUI
 control: Shimmer
 documentation: ug
@@ -9,18 +9,18 @@ documentation: ug
 
 # Getting Started with WinUI Shimmer
 
-This section explains the steps required to add the [WinUI Shimmer control](https://www.syncfusion.com/winui-controls/shimmer) and covers only the basic features needed to get started with the Shimmer control.
+This section explains the steps required to add the [WinUI Shimmer control](https://www.syncfusion.com/winui-controls/shimmer) and covers the basic features you need to get started.
 
-## Creating an application with WinUI Shimmer control
+## Creating an application with the WinUI Shimmer control
 
-1. Create a [WinUI 3 desktop app for C# and .NET 6](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/get-started-winui3-for-desktop).
-2. Add reference to [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet. 
-3. Import the control namespace `Syncfusion.UI.Xaml.Core` in XAML or C# code.
+1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/get-started-winui3-for-desktop).
+2. Add reference to the [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet package.
+3. Import the `Syncfusion.UI.Xaml.Core` namespace in your XAML or C# code.
 4. Initialize the [SfShimmer](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShimmer.html) control.
 
-## Initializing Shimmer control 
+## Initializing Shimmer control
 
-To initialize the Shimmer control, you can simply add the `SfShimmer` control in your XAML or C# code.
+To initialize the Shimmer control, add `SfShimmer` to your XAML page or instantiate it in code-behind.
 
 {% tabs %}
 {% highlight xaml %}
@@ -31,7 +31,7 @@ To initialize the Shimmer control, you can simply add the `SfShimmer` control in
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:GettingStarted"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:syncfusion="using:Syncfusion.UI.Xaml.Core"
     mc:Ignorable="d">
     <Grid>
@@ -43,8 +43,22 @@ To initialize the Shimmer control, you can simply add the `SfShimmer` control in
 {% highlight C# %}
 
 // Creating an instance of the Shimmer control.
-SfShimmer Shimmer = new SfShimmer();
-           
+using Microsoft.UI.Xaml;
+using Syncfusion.UI.Xaml.Core;
+
+namespace GettingStarted
+{
+    public sealed partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+            SfShimmer shimmer = new SfShimmer();
+            this.Content = shimmer;
+        }
+    }
+}
+
 {% endhighlight %}
 {% endtabs %}
 

--- a/winui/Shimmer/Getting-Started.md
+++ b/winui/Shimmer/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WinUI Shimmer | Syncfusion®
-description: Learn how to get started with the Syncfusion® WinUI Shimmer control. Explore setup, features, examples, and customization options.
+title: Getting Started with WinUI Shimmer | SyncfusionÂ®
+description: Learn how to get started with the SyncfusionÂ® WinUI Shimmer control. Explore setup, features, examples, and customization options.
 platform: WinUI
 control: Shimmer
 documentation: ug
@@ -9,18 +9,18 @@ documentation: ug
 
 # Getting Started with WinUI Shimmer
 
-This section explains the steps required to add the [WinUI Shimmer control](https://www.syncfusion.com/winui-controls/shimmer) and covers the basic features you need to get started.
+This section explains how to get started with the [WinUI Shimmer control](https://www.syncfusion.com/winui-controls/shimmer) in a WinUI application and covers the basic steps required to add and use the control.
 
 ## Creating an application with the WinUI Shimmer control
 
-1. Create a [WinUI 3 desktop app for C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/get-started-winui3-for-desktop).
-2. Add reference to the [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet package.
-3. Import the `Syncfusion.UI.Xaml.Core` namespace in your XAML or C# code.
-4. Initialize the [SfShimmer](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShimmer.html) control.
+1. Create a [WinUI 3 desktop application in C#](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/get-started-winui3-for-desktop).
+2. Install the [Syncfusion.Core.WinUI](https://www.nuget.org/packages/Syncfusion.Core.WinUI) NuGet package.
+3. Import the **Syncfusion.UI.Xaml.Core** namespace in XAML or C#.
+4. Add and initialize the [SfShimmer](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShimmer.html) control.
 
 ## Initializing Shimmer control
 
-To initialize the Shimmer control, add `SfShimmer` to your XAML page or instantiate it in code-behind.
+You can add the [SfShimmer](https://help.syncfusion.com/cr/winui/Syncfusion.UI.Xaml.Core.SfShimmer.html) control in XAML or create an instance of it programmatically in code-behind.
 
 {% tabs %}
 {% highlight xaml %}
@@ -62,4 +62,4 @@ namespace GettingStarted
 {% endhighlight %}
 {% endtabs %}
 
-![WinUI Shimmer control overview](Shimmer_Images/winui_shimmer_getting_started.gif)
+![WinUI Shimmer control](Shimmer_Images/winui_shimmer_getting_started.gif)


### PR DESCRIPTION
### Task Description ###
[Task 1046901](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/1046901): Fix the getting started documentation issue for tools controls in WinUI platform.

### Description ###
Updated the UG Documentation for the GettingStarted page for below controls:

- SfBusyIndicator.
- SfShadow.
- SfShimmer

### AI Usage ###

<b>Code Studio used in this PR/MR?</b>

* [x] Yes
* [ ] No

If <b>Yes</b>: Primary use (choose one)

* [ ] Generate new code
* [ ] Refactor/improve existing code
* [ ] Tests
* [ ] Bug fix / debugging help
* [x] Docs / comments
* [ ] Review assistance (explanations/summaries)
* [ ] Other

<b>Outcome</b>
* [x] Saved time (AI made development faster)
* [ ] Neutral (No major difference)
* [ ] Cost time (AI slowed things down)
 
If <b>Cost time</b>: Provide one line explanation